### PR TITLE
Added helper extension function MapFromSourceObject

### DIFF
--- a/netcore/src/OPADotNet.Automapper/Extensions/MemberConfigurationExpressionExtensions.cs
+++ b/netcore/src/OPADotNet.Automapper/Extensions/MemberConfigurationExpressionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using OPADotNet.Automapper;
+using OPADotNet.Automapper.Internal;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -17,6 +18,18 @@ namespace AutoMapper
         private static bool FromPolicyBasedOnDestination(string name)
         {
             return false;
+        }
+
+        /// <summary>
+        /// Equivalent to writing MapFrom(src => src);
+        /// </summary>
+        /// <typeparam name="TSource"></typeparam>
+        /// <typeparam name="TDestination"></typeparam>
+        /// <typeparam name="TMember"></typeparam>
+        /// <param name="memberConfigurationExpression"></param>
+        public static void MapFromSourceObject<TSource, TDestination, TMember>(this IMemberConfigurationExpression<TSource, TDestination, TMember> memberConfigurationExpression)
+        {
+            memberConfigurationExpression.MapFrom(x => x);
         }
 
         public static void MapFromPolicy<TSource, TDestination>(this IMemberConfigurationExpression<TSource, TDestination, bool> memberConfigurationExpression, string policyName)

--- a/samples/MvcExample/Startup.cs
+++ b/samples/MvcExample/Startup.cs
@@ -52,7 +52,7 @@ namespace MvcExample
             services.AddAutoMapper(opt =>
             {
                 opt.CreateMap<DataModel, ViewModel>(MemberList.Destination)
-                    .ForMember(x => x.Permissions, opt => opt.MapFrom(src => src));
+                    .ForMember(x => x.Permissions, opt => opt.MapFromSourceObject());
 
                 opt.CreateMap<DataModel, Permissions>()
                     .ForMember(x => x.CanEdit, opt => opt.MapFromPolicy("can_edit"))


### PR DESCRIPTION
This can be used instead of writing MapFrom(x => x); useful when wanting to map a permissions object from source.