### PR TITLE
Fix so null checks are not done on references when using EF core.

### DIFF
--- a/netcore/src/OPADotNet.AspNetCore/AuthorizeQueryableHolder.cs
+++ b/netcore/src/OPADotNet.AspNetCore/AuthorizeQueryableHolder.cs
@@ -11,6 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using OPADotNet.Expressions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -23,6 +24,7 @@ namespace OPADotNet.AspNetCore
     {
         public Type EntityType { get; }
         public ParameterExpression ParameterExpression { get; }
+        public ExpressionConversionOptions Options { get; }
 
         private readonly List<Expression> expressions = new List<Expression>();
 
@@ -45,10 +47,11 @@ namespace OPADotNet.AspNetCore
             return Expression.Lambda(expr, ParameterExpression);
         }
 
-        public AuthorizeQueryableHolder(Type entityType, ParameterExpression parameterExpression)
+        public AuthorizeQueryableHolder(Type entityType, ParameterExpression parameterExpression, ExpressionConversionOptions options)
         {
             EntityType = entityType;
             ParameterExpression = parameterExpression;
+            Options = options;
         }
     }
 }

--- a/netcore/src/OPADotNet.AspNetCore/Requirements/OpaPolicyHandler.cs
+++ b/netcore/src/OPADotNet.AspNetCore/Requirements/OpaPolicyHandler.cs
@@ -123,7 +123,7 @@ namespace OPADotNet.AspNetCore.Requirements
                 return;
             }
 
-            var expression = await _expressionConverter.ToExpression(result, requirement.GetUnknown(), authorizeQueryableHolder.ParameterExpression);
+            var expression = await _expressionConverter.ToExpression(result, requirement.GetUnknown(), authorizeQueryableHolder.ParameterExpression, authorizeQueryableHolder.Options);
             authorizeQueryableHolder.AddFilter(expression);
             context.Succeed(requirement);
         }

--- a/netcore/src/OPADotNet.Expressions/Ast/Conversion/PartialToAstVisitor.cs
+++ b/netcore/src/OPADotNet.Expressions/Ast/Conversion/PartialToAstVisitor.cs
@@ -90,7 +90,8 @@ namespace OPADotNet.Expressions.Ast
                 {
                     Type = BooleanComparisonType.NotEqualTo,
                     Left = leftScalar,
-                    Right = NullLiteral.Defult
+                    Right = NullLiteral.Defult,
+                    IsReferenceNullCheck = true
                 };
             }
             if (partialExpression.Terms.Count != 3)

--- a/netcore/src/OPADotNet.Expressions/Ast/Models/BooleanComparisonExpression.cs
+++ b/netcore/src/OPADotNet.Expressions/Ast/Models/BooleanComparisonExpression.cs
@@ -25,6 +25,8 @@ namespace OPADotNet.Expressions.Ast.Models
 
         public BooleanComparisonType Type { get; set; }
 
+        public bool IsReferenceNullCheck { get; set; }
+
         public override T Accept<T>(ExpressionAstVisitor<T> visitor)
         {
             return visitor.VisitBooleanComparisonExpression(this);

--- a/netcore/src/OPADotNet.Expressions/ExpressionConversionOptions.cs
+++ b/netcore/src/OPADotNet.Expressions/ExpressionConversionOptions.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OPADotNet.Expressions
+{
+    public class ExpressionConversionOptions
+    {
+        public bool IgnoreNotNullReferenceChecks { get; set; }
+    }
+}

--- a/samples/MvcExample/policies/read.rego
+++ b/samples/MvcExample/policies/read.rego
@@ -3,5 +3,10 @@
 # This policy regards which resources a user can read
 
 allow {
-  data.securedata[_].owner = input.subject.name
+  allowed[_]
+}
+
+allowed[secure] {
+  secure := data.securedata[_]
+  secure.owner == input.subject.name
 }


### PR DESCRIPTION
Doing null checks on EF core can cause issues on more complex data types.