### PR TITLE
Added support to parse modules when doing partial eval

### DIFF
--- a/netcore/src/OPADotNet.Core/Ast/AstVisitor.cs
+++ b/netcore/src/OPADotNet.Core/Ast/AstVisitor.cs
@@ -46,6 +46,7 @@ namespace OPADotNet.Ast
         public virtual T VisitQueries(AstQueries partialQueries)
         {
             Visit(partialQueries.Queries);
+            Visit(partialQueries.Modules);
             return default;
         }
 
@@ -111,12 +112,14 @@ namespace OPADotNet.Ast
         {
             Visit(policyRule.Body);
             Visit(policyRule.Head);
+            Visit(policyRule.Else);
             return default;
         }
 
         public virtual T VisitRuleHead(AstRuleHead ruleHead)
         {
             Visit(ruleHead.Value);
+            Visit(ruleHead.Key);
             return default;
         }
 

--- a/netcore/src/OPADotNet.Core/Ast/Models/AstPolicyRule.cs
+++ b/netcore/src/OPADotNet.Core/Ast/Models/AstPolicyRule.cs
@@ -25,6 +25,9 @@ namespace OPADotNet.Ast.Models
         [JsonPropertyName("body")]
         public AstBody Body { get; set; }
 
+        [JsonPropertyName("else")]
+        public AstPolicyRule Else { get; set; }
+
         public override T Accept<T>(AstVisitor<T> visitor)
         {
             return visitor.VisitPolicyRule(this);
@@ -35,14 +38,15 @@ namespace OPADotNet.Ast.Models
             if (obj is AstPolicyRule other)
             {
                 return Equals(Head, other.Head) &&
-                    Equals(Body, other.Body);
+                    Equals(Body, other.Body) &&
+                    Equals(Else, other.Else);
             }
             return false;
         }
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(Head, Body);
+            return HashCode.Combine(Head, Body, Else);
         }
     }
 }

--- a/netcore/src/OPADotNet.Core/Ast/Models/AstQueries.cs
+++ b/netcore/src/OPADotNet.Core/Ast/Models/AstQueries.cs
@@ -24,6 +24,9 @@ namespace OPADotNet.Ast.Models
         [JsonPropertyName("queries")]
         public List<AstBody> Queries { get; set; }
 
+        [JsonPropertyName("modules")]
+        public List<AstPolicy> Modules { get; set; }
+
         public override T Accept<T>(AstVisitor<T> visitor)
         {
             return visitor.VisitQueries(this);
@@ -33,7 +36,8 @@ namespace OPADotNet.Ast.Models
         {
             if (obj is AstQueries other)
             {
-                return Queries.AreEqual(other.Queries);
+                return Queries.AreEqual(other.Queries) &&
+                    Modules.AreEqual(other.Modules);
             }
             return false;
         }
@@ -45,6 +49,14 @@ namespace OPADotNet.Ast.Models
             {
                 hashCode.Add(query);
             }
+            if (Modules != null)
+            {
+                foreach (var module in Modules)
+                {
+                    hashCode.Add(module);
+                }
+            }
+            
             return hashCode.ToHashCode();
         }
     }

--- a/netcore/src/OPADotNet.Core/Ast/Models/AstRuleHead.cs
+++ b/netcore/src/OPADotNet.Core/Ast/Models/AstRuleHead.cs
@@ -25,6 +25,9 @@ namespace OPADotNet.Ast.Models
         [JsonPropertyName("value")]
         public AstTerm Value { get; set; }
 
+        [JsonPropertyName("key")]
+        public AstTerm Key { get; set; }
+
         public override T Accept<T>(AstVisitor<T> visitor)
         {
             return visitor.VisitRuleHead(this);
@@ -35,14 +38,15 @@ namespace OPADotNet.Ast.Models
             if (obj is AstRuleHead other)
             {
                 return Equals(Name, other.Name) &&
-                    Equals(Value, other.Value);
+                    Equals(Value, other.Value) &&
+                    Equals(Key, other.Key);
             }
             return false;
         }
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(Name, Value);
+            return HashCode.Combine(Name, Value, Key);
         }
     }
 }


### PR DESCRIPTION
This helps to get the more correct AST tree when doing partial evaluations