### PR TITLE
Removed requiring authenticated user.

### DIFF
--- a/docs/source/inputvalues.csv
+++ b/docs/source/inputvalues.csv
@@ -3,6 +3,7 @@ input.subject.name; The current user name, translated from claimsPrincipal.Ident
 input.subject.claims[]; An array of the current user claims
 input.subject.claims[_].type; The type that the claim is, for example "role".
 input.subject.claims[_].value; The value of the claim.
+input.subject.isAuthenticated; Is the current user authenticated or not.
 input.operation; The operation name set when configuring the policy.
 input.request; Contains an object with information of the current http request
 input.request.path[]; Contains an array of the url path which is split by '/', example: "test/testing" becomes ["test", "testing"]

--- a/netcore/src/OPADotNet.AspNetCore/Input/OpaInputUser.cs
+++ b/netcore/src/OPADotNet.AspNetCore/Input/OpaInputUser.cs
@@ -30,21 +30,24 @@ namespace OPADotNet.AspNetCore.Input
         [JsonPropertyName("claims")]
         public List<OpaInputUserClaim> Claims { get; set; }
 
+        [JsonPropertyName("isAuthenticated")]
+        public bool IsAuthenticated { get; set; }
+
         public static OpaInputUser FromPrincipal(ClaimsPrincipal claimsPrincipal)
         {
-            if (!claimsPrincipal?.Identity?.IsAuthenticated ?? true)
-            {
-                return null;
-            }
             var output = new OpaInputUser()
             {
-                Name = claimsPrincipal.Identity.Name,
-                Claims = new List<OpaInputUserClaim>()
+                Name = claimsPrincipal?.Identity?.Name,
+                Claims = new List<OpaInputUserClaim>(),
+                IsAuthenticated = claimsPrincipal?.Identity?.IsAuthenticated ?? false
             };
 
-            foreach (var claim in claimsPrincipal.Claims)
+            if (claimsPrincipal?.Claims != null)
             {
-                output.Claims.Add(OpaInputUserClaim.FromClaim(claim));
+                foreach (var claim in claimsPrincipal.Claims)
+                {
+                    output.Claims.Add(OpaInputUserClaim.FromClaim(claim));
+                }
             }
 
             return output;


### PR DESCRIPTION
Instead of relying on that the OPA plugin does the check, one can either use the new input.subject.isAuthenticated property in the policy or use RequireAuthenticatedUser() when setting up the policy.