### PR TITLE
Changed claims to be added as a dictionary for the subject.

### DIFF
--- a/docs/source/inputvalues.csv
+++ b/docs/source/inputvalues.csv
@@ -1,7 +1,7 @@
 input.subject; The current user
 input.subject.name; The current user name, translated from claimsPrincipal.Identity.Name
 input.subject.claims[_]; A dictionary of the current user claims
-input.subject.claims.{claimsName}.[_]; An array of the values on a specfic claim.
+input.subject.claims.{claimsName}[_]; An array of the values on a specfic claim.
 input.subject.isAuthenticated; Is the current user authenticated or not.
 input.operation; The operation name set when configuring the policy.
 input.request; Contains an object with information of the current http request

--- a/docs/source/inputvalues.csv
+++ b/docs/source/inputvalues.csv
@@ -1,8 +1,7 @@
 input.subject; The current user
 input.subject.name; The current user name, translated from claimsPrincipal.Identity.Name
-input.subject.claims[]; An array of the current user claims
-input.subject.claims[_].type; The type that the claim is, for example "role".
-input.subject.claims[_].value; The value of the claim.
+input.subject.claims[_]; A dictionary of the current user claims
+input.subject.claims.{claimsName}.[_]; An array of the values on a specfic claim.
 input.subject.isAuthenticated; Is the current user authenticated or not.
 input.operation; The operation name set when configuring the policy.
 input.request; Contains an object with information of the current http request

--- a/netcore/src/OPADotNet.AspNetCore/Input/OpaInputUser.cs
+++ b/netcore/src/OPADotNet.AspNetCore/Input/OpaInputUser.cs
@@ -28,7 +28,7 @@ namespace OPADotNet.AspNetCore.Input
         public string Name { get; set; }
 
         [JsonPropertyName("claims")]
-        public List<OpaInputUserClaim> Claims { get; set; }
+        public Dictionary<string, List<string>> Claims { get; set; }
 
         [JsonPropertyName("isAuthenticated")]
         public bool IsAuthenticated { get; set; }
@@ -38,7 +38,7 @@ namespace OPADotNet.AspNetCore.Input
             var output = new OpaInputUser()
             {
                 Name = claimsPrincipal?.Identity?.Name,
-                Claims = new List<OpaInputUserClaim>(),
+                Claims = new Dictionary<string, List<string>>(),
                 IsAuthenticated = claimsPrincipal?.Identity?.IsAuthenticated ?? false
             };
 
@@ -46,7 +46,12 @@ namespace OPADotNet.AspNetCore.Input
             {
                 foreach (var claim in claimsPrincipal.Claims)
                 {
-                    output.Claims.Add(OpaInputUserClaim.FromClaim(claim));
+                    if (!output.Claims.TryGetValue(claim.Type, out var claims))
+                    {
+                        claims = new List<string>();
+                        output.Claims.Add(claim.Type, claims);
+                    }
+                    claims.Add(claim.Value);
                 }
             }
 


### PR DESCRIPTION
This is changed to make the execution faster to check specfic claims for a user, also simplifies checking claims in the policy.

Checking if a user has a scope before:

```
must_have_scope {
  claim := input.subject.claims[_]
  claim.type = "scope"
  claim.value = "scopename"
}
```

New way to check scopes:

```
must_have_scope {
  input.subject.claims.scope[_] = "scopename"
}
```